### PR TITLE
Add support for sending a file over RTPDataChannel

### DIFF
--- a/src/components/Home/Home.css.js
+++ b/src/components/Home/Home.css.js
@@ -2,8 +2,5 @@ export default {
     container: {
         marginTop: '250px',
         height: '100vh'
-    },
-    button: {
-        marginTop: '20px'
     }
 }

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -19,10 +19,6 @@ class Home extends React.Component {
     this.props.joinRoom(this.state.roomName, this.state.userName);
   };
 
-  handleSendButtonClick = () => {
-    this.props.sendData('Hi. This is my first webRTC message');
-  };
-
   handleRoomNameChange = event => {
     this.setState({
       roomName: event.target.value
@@ -56,28 +52,17 @@ class Home extends React.Component {
   };
 
   displayJoinedContent = () => {
-    const { classes } = this.props;
     return (
       <Grid container direction="column" justify="center" alignItems="center">
-        <Grid item xs={2}>
+        <Grid item xs={6}>
           <Typography> Peers in room {this.props.room}</Typography>
         </Grid>
-        <Grid item xs={2}>
+        <Grid item xs={6}>
           <Grid container direction="row">
             {this.props.peers.map(peer => (
-              <Peer key={peer} name={peer} />
+              <Peer key={peer} name={peer} peerType={this.props.peerType} sendFile={this.props.sendFile} />
             ))}
           </Grid>
-        </Grid>
-        <Grid item xs={2}>
-          <Button
-            className={classes.button}
-            variant="contained"
-            color="primary"
-            onClick={this.handleSendButtonClick}
-          >
-            Send
-          </Button>
         </Grid>
       </Grid>
     );

--- a/src/components/Peers/Peer.css.js
+++ b/src/components/Peers/Peer.css.js
@@ -2,5 +2,8 @@ export default {
     image: {
         width: '50px',
         height: '50px'
+    },
+    button: {
+        marginTop: '20px'
     }
 }

--- a/src/components/Peers/Peer.js
+++ b/src/components/Peers/Peer.js
@@ -1,23 +1,66 @@
 import React from 'react';
 import faker from 'faker';
 import { withStyles } from '@material-ui/core/styles';
-import { Typography, Grid } from '@material-ui/core';
+import { Typography, Grid, Button } from '@material-ui/core';
 import styles from './Peer.css';
+import PeerTypes from '../../enums/PeerTypes';
 
-const Peer = props => {
-  const { classes } = props;
-  return (
-    <Grid container direction="column" justify="center" alignItems="center">
-      <Grid item>
-        <img
-          alt="Avatar"
-          className={classes.image}
-          src={faker.image.avatar()}
-        ></img>
-        <Typography>{faker.name.firstName()}</Typography>
-      </Grid>
-    </Grid>
-  );
+
+class Peer extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.fileInputRef = React.createRef();
+  }
+
+  handleFormSubmit = (event) => {
+    event.preventDefault();
+    this.props.sendFile(this.fileInputRef.current.files[0]);
+  }
+
+  loadSendButton = () => {
+    const { classes } = this.props;
+    return (
+      <form onSubmit={this.handleFormSubmit}>
+        <Grid container direction="column" justify="center" alignItems="center">
+          <Grid item xs={6}>
+            <input
+              name="file"
+              type="file"
+              ref={this.fileInputRef} />
+          </Grid>
+          <Grid item xs={2}>
+            <Button
+              className={classes.button}
+              variant="contained"
+              color="primary"
+              type="submit"
+            >
+              Send
+          </Button>
+          </Grid>
+        </Grid>
+      </form>
+    );
+  }
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <Grid container direction="column" justify="center" alignItems="center">
+        <Grid item>
+          <img
+            alt="Avatar"
+            className={classes.image}
+            src={faker.image.avatar()}
+          ></img>
+          <Typography>{faker.name.firstName()}</Typography>
+          {(this.props.peerType && this.props.peerType === PeerTypes.SENDER) ? this.loadSendButton() : null}
+        </Grid>
+      </Grid >
+    );
+  }
+
 };
 
 export default withStyles(styles)(Peer);

--- a/src/components/SocketConnection/withConnection.js
+++ b/src/components/SocketConnection/withConnection.js
@@ -4,6 +4,7 @@ import io from 'socket.io-client';
 import ConnectionStates from '../../enums/ConnectionStates';
 import DataChannelTypes from '../../enums/DataChannelTypes';
 import AppConstants from '../../utils/AppConstants';
+import PeerTypes from '../../enums/PeerTypes';
 
 const withConnection = WrappedComponent =>
   class Connection extends React.Component {
@@ -21,7 +22,8 @@ const withConnection = WrappedComponent =>
         room: null,
         myId: null,
         peerConnection: null,
-        dataChannel: null
+        dataChannel: null,
+        peerType: null
       };
     }
 
@@ -71,7 +73,8 @@ const withConnection = WrappedComponent =>
         myId: id,
         peers: existingPeers
           ? existingPeers.filter(peerId => peerId !== id)
-          : []
+          : [],
+        peerType: existingPeers ? PeerTypes.RECIPIENT : PeerTypes.SENDER
       });
     };
 
@@ -200,11 +203,21 @@ const withConnection = WrappedComponent =>
 
     onReceiveMessage = event => {
       console.log('onReceiveMessage', event.data);
+      this.downloadBlob(event.data, 'test.jpg')
+
     };
 
     onReceiveChannelStateChange = event => {
       console.log('onReceiveChannelStateChange', event);
     };
+
+    downloadBlob = (blob, filename) => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename || 'download';
+      a.click();
+    }
 
     // Child component prop methods
 
@@ -212,8 +225,8 @@ const withConnection = WrappedComponent =>
       this.socket.emit('join', roomName);
     };
 
-    sendData = data => {
-      this.dataChannel.send(data);
+    sendFile = file => {
+      this.dataChannel.send(file);
     };
 
     render() {
@@ -221,7 +234,7 @@ const withConnection = WrappedComponent =>
         <WrappedComponent
           {...this.state}
           joinRoom={this.joinRoom}
-          sendData={this.sendData}
+          sendFile={this.sendFile}
         />
       );
     }

--- a/src/enums/PeerTypes.js
+++ b/src/enums/PeerTypes.js
@@ -1,0 +1,4 @@
+export default {
+    SENDER: 'SENDER',
+    RECIPIENT: 'RECIPIENT'
+}


### PR DESCRIPTION
- Remove the sample string that was being sent previously
- Change the view for Peers based on whether they are a SENDER or a RECIPIENT
- Show send button and the file input elements only for a SENDER
- First one to enter the web app is the SENDER, the second one is the RECIPIENT.
- SENDER can send a file to RECIPIENT
- Send and receive file as blob.

Issues:
- Chrome does not support sending blobs over RTCDataChannel yet.
- Send and receive works fine for firefox in desktop, but receive not working in firefox for mobile.