### PR TITLE
feat: Move RTCPeerConnection management to individual peers

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -11,6 +11,7 @@ import Peer from '../Peers/Peer';
 
 import styles from './Home.css.js';
 import ConnectionStates from '../../enums/ConnectionStates.js';
+import withPeerConnection from '../SocketConnection/withPeerConnection';
 
 class Home extends React.Component {
   state = { roomName: 'default' };
@@ -59,9 +60,16 @@ class Home extends React.Component {
         </Grid>
         <Grid item xs={6}>
           <Grid container direction="row">
-            {this.props.peers.map(peer => (
-              <Peer key={peer} name={peer} peerType={this.props.peerType} sendFile={this.props.sendFile} />
-            ))}
+            {this.props.peers.map(peer => {
+              const PeerWithPeerConnection = withPeerConnection(Peer);
+              return (
+                <PeerWithPeerConnection
+                  key={peer}
+                  peerId={peer}
+                  peerType={this.props.peerType}
+                />
+              );
+            })}
           </Grid>
         </Grid>
       </Grid>

--- a/src/components/Peers/Peer.js
+++ b/src/components/Peers/Peer.js
@@ -4,19 +4,18 @@ import { withStyles } from '@material-ui/core/styles';
 import { Typography, Grid, Button } from '@material-ui/core';
 import styles from './Peer.css';
 import PeerTypes from '../../enums/PeerTypes';
-
+import SocketContext from '../../contexts/SocketContext';
 
 class Peer extends React.Component {
-
   constructor(props) {
     super(props);
     this.fileInputRef = React.createRef();
   }
 
-  handleFormSubmit = (event) => {
+  handleFormSubmit = event => {
     event.preventDefault();
-    this.props.sendFile(this.fileInputRef.current.files[0]);
-  }
+    this.props.sendFiles(this.fileInputRef.current.files);
+  };
 
   loadSendButton = () => {
     const { classes } = this.props;
@@ -24,10 +23,7 @@ class Peer extends React.Component {
       <form onSubmit={this.handleFormSubmit}>
         <Grid container direction="column" justify="center" alignItems="center">
           <Grid item xs={6}>
-            <input
-              name="file"
-              type="file"
-              ref={this.fileInputRef} />
+            <input name="file" type="file" ref={this.fileInputRef} />
           </Grid>
           <Grid item xs={2}>
             <Button
@@ -37,12 +33,12 @@ class Peer extends React.Component {
               type="submit"
             >
               Send
-          </Button>
+            </Button>
           </Grid>
         </Grid>
       </form>
     );
-  }
+  };
 
   render() {
     const { classes } = this.props;
@@ -55,12 +51,15 @@ class Peer extends React.Component {
             src={faker.image.avatar()}
           ></img>
           <Typography>{faker.name.firstName()}</Typography>
-          {(this.props.peerType && this.props.peerType === PeerTypes.SENDER) ? this.loadSendButton() : null}
+          {this.props.peerType && this.props.peerType === PeerTypes.SENDER
+            ? this.loadSendButton()
+            : null}
         </Grid>
-      </Grid >
+      </Grid>
     );
   }
+}
 
-};
+Peer.contextType = SocketContext;
 
 export default withStyles(styles)(Peer);

--- a/src/components/SocketConnection/withConnection.js
+++ b/src/components/SocketConnection/withConnection.js
@@ -2,51 +2,43 @@ import React from 'react';
 import io from 'socket.io-client';
 
 import ConnectionStates from '../../enums/ConnectionStates';
-import DataChannelTypes from '../../enums/DataChannelTypes';
 import AppConstants from '../../utils/AppConstants';
 import PeerTypes from '../../enums/PeerTypes';
 
+import SocketContext from '../../contexts/SocketContext';
+
 const withConnection = WrappedComponent =>
   class Connection extends React.Component {
+    state = {
+      socket: null,
+      peers: [],
+      connectionState: ConnectionStates.NOT_JOINED,
+      room: null,
+      myId: null,
+      peerType: null
+    };
+
     // Component Lifecycle methods
-    constructor(props) {
-      super();
-
-      this.socket = null;
-      this.peerConnection = null;
-      this.dataChannel = null;
-
-      this.state = {
-        peers: [],
-        connectionState: ConnectionStates.NOT_JOINED,
-        room: null,
-        myId: null,
-        peerConnection: null,
-        dataChannel: null,
-        peerType: null
-      };
-    }
 
     componentDidMount() {
       // Initialize socket connection
-      this.socket = io(AppConstants.SOCKET_SERVER_URI);
+      const socket = io(AppConstants.SOCKET_SERVER_URI);
 
       // Socket connection listeners
-      this.socket.on('connect', this.onSocketConnected);
-      this.socket.on('disconnect', this.onSocketDisconnected);
+      socket.on('connect', this.onSocketConnected);
+      socket.on('disconnect', this.onSocketDisconnected);
 
       // Listeners for room
-      this.socket.on('joined', this.handleRoomJoinSuccess);
-      this.socket.on('roommate', this.handleNewRoommate);
+      socket.on('joined', this.handleRoomJoinSuccess);
+      socket.on('roommate', this.handleNewRoommate);
 
-      // Webrtc signalling message listeners
-      this.socket.on('offer', this.onOfferReceived);
-      this.socket.on('answer', this.onAnswerReceived);
-      this.socket.on('candidate', this.onCandidateReceived);
+      this.setState({
+        socket
+      });
     }
 
     componentWillUnmount() {
-      this.socket.disconnect();
+      this.state.socket.disconnect();
     }
 
     // socket.io-client callbacks/handlers
@@ -61,12 +53,6 @@ const withConnection = WrappedComponent =>
 
     handleRoomJoinSuccess = (room, id, existingPeers) => {
       console.log('Joined', room, id, existingPeers);
-      this.createPeerConnection();
-      if (existingPeers && existingPeers.length === 2) {
-        this.createDataChannel(DataChannelTypes.RECEIVE);
-      } else {
-        this.createDataChannel(DataChannelTypes.SEND);
-      }
       this.setState({
         connectionState: ConnectionStates.JOINED,
         room: room,
@@ -81,7 +67,6 @@ const withConnection = WrappedComponent =>
     handleNewRoommate = async (room, id) => {
       try {
         console.log('New roommate', room, id);
-        await this.createAndSendOffer();
         this.setState({
           peers: [...this.state.peers, id]
         });
@@ -90,152 +75,17 @@ const withConnection = WrappedComponent =>
       }
     };
 
-    onOfferReceived = async desc => {
-      console.log('Offer received', desc);
-      try {
-        await this.peerConnection.setRemoteDescription(desc);
-        await this.peerConnection.setLocalDescription(
-          await this.peerConnection.createAnswer()
-        );
-        this.sendAnswer(this.peerConnection.localDescription);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-
-    onAnswerReceived = async desc => {
-      console.log('Answer received', desc);
-      await this.peerConnection.setRemoteDescription(desc);
-    };
-
-    onCandidateReceived = async iceCandidate => {
-      try {
-        console.log('Candidate received', iceCandidate);
-        // await this.peerConnection.addIceCandidate(iceCandidate);
-        await this.peerConnection.addIceCandidate(
-          new RTCIceCandidate({
-            candidate: iceCandidate.candidate.candidate,
-            sdpMid: iceCandidate.candidate.sdpMid,
-            sdpMLineIndex: iceCandidate.candidate.sdpMLineIndex,
-            usernameFragment: iceCandidate.candidate.userNameFragment
-          })
-        );
-      } catch (error) {
-        console.log(error);
-      }
-    };
-
-    // WebRTC signalling helper methods
-
-    createAndSendOffer = async () => {
-      try {
-        // Without sending offerToReceiveAudio or offerToReceiveVideo in the offer config,
-        // SDP is not getting set properly
-        const offer = await this.peerConnection.createOffer({
-          offerToReceiveAudio: true,
-          offerToReceiveVideo: true
-        });
-        await this.peerConnection.setLocalDescription(offer);
-        this.sendOffer(offer);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-
-    createDataChannel = datachannelType => {
-      if (datachannelType === DataChannelTypes.SEND) {
-        console.log('Create sendDataChannel');
-        const sendChannel = this.peerConnection.createDataChannel(
-          'sendDataChannel'
-        );
-        this.dataChannel = sendChannel;
-      } else if (datachannelType === DataChannelTypes.RECEIVE) {
-        this.peerConnection.ondatachannel = event => {
-          console.log('ReceiveDataChannel event triggered');
-          const receiveChannel = event.channel;
-          receiveChannel.onmessage = this.onReceiveMessage;
-          receiveChannel.onopen = this.onReceiveChannelStateChange;
-          receiveChannel.onclose = this.onReceiveChannelStateChange;
-          this.dataChannel = receiveChannel;
-        };
-      }
-    };
-
-    createPeerConnection = () => {
-      console.log('Creating peer connection');
-      this.peerConnection = new RTCPeerConnection();
-      this.peerConnection.onicecandidate = iceCandidate => {
-        if (iceCandidate.candidate === null) {
-          console.log('Candidate discovery ended');
-        } else {
-          console.log('Candidate discovered', iceCandidate);
-
-          // socket.io-client seem to enumerate iceCandidate object internally.
-          // All non-enumerable properties are getting ignored while emitting event.
-          // Hence we need to manually construct a new object and send.
-
-          this.sendCandidate({
-            candidate: iceCandidate.candidate,
-            sdpMid: iceCandidate.sdpMid,
-            sdpMLineIndex: iceCandidate.sdpMLineIndex,
-            userNameFragment: iceCandidate.userNameFragment
-          });
-        }
-      };
-    };
-
-    sendOffer = offer => {
-      console.log('Sending offer', this.state.room, offer);
-      this.socket.emit('offer', this.state.room, offer);
-    };
-
-    sendCandidate = candidate => {
-      console.log('Sending candidate', this.state.room, candidate);
-      this.socket.emit('candidate', this.state.room, candidate);
-    };
-
-    sendAnswer = answer => {
-      console.log('Sending answer', this.state.room, answer);
-      this.socket.emit('answer', this.state.room, answer);
-    };
-
-    // DataChannel callbacks
-
-    onReceiveMessage = event => {
-      console.log('onReceiveMessage', event.data);
-      this.downloadBlob(event.data, 'test.jpg')
-
-    };
-
-    onReceiveChannelStateChange = event => {
-      console.log('onReceiveChannelStateChange', event);
-    };
-
-    downloadBlob = (blob, filename) => {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename || 'download';
-      a.click();
-    }
-
     // Child component prop methods
 
     joinRoom = roomName => {
-      this.socket.emit('join', roomName);
-    };
-
-    sendFile = file => {
-      this.dataChannel.send(file);
+      this.state.socket.emit('join', roomName);
     };
 
     render() {
       return (
-        <WrappedComponent
-          {...this.state}
-          joinRoom={this.joinRoom}
-          sendFile={this.sendFile}
-        />
+        <SocketContext.Provider value={this.state}>
+          <WrappedComponent {...this.state} joinRoom={this.joinRoom} />
+        </SocketContext.Provider>
       );
     }
   };

--- a/src/components/SocketConnection/withPeerConnection.js
+++ b/src/components/SocketConnection/withPeerConnection.js
@@ -1,0 +1,281 @@
+import React from 'react';
+import SocketContext from '../../contexts/SocketContext';
+import DataChannelTypes from '../../enums/DataChannelTypes';
+import PeerTypes from '../../enums/PeerTypes';
+
+const withPeerConnection = WrappedComponent => {
+  class PeerConnection extends React.Component {
+    state = {
+      files: null,
+      incomingFileInfo: null
+    };
+
+    constructor(props) {
+      super(props);
+      this.peerConnection = null;
+      this.dataChannel = null;
+    }
+
+    componentDidMount() {
+      // Webrtc signalling message listeners
+      this.context.socket.on('offer', this.onOfferReceived);
+      this.context.socket.on('answer', this.onAnswerReceived);
+      this.context.socket.on('candidate', this.onCandidateReceived);
+
+      this.context.socket.on('fileInfo', this.onFileInfoReceived);
+      this.context.socket.on('ready', this.onPeerReadyForDataTransfer);
+    }
+
+    // RTCPeerConnection management methods.
+
+    setupPeerConnectionForDataTransfer = async () => {
+      try {
+        this.createPeerConnection();
+        if (this.context.peerType === PeerTypes.SENDER) {
+          this.createDataChannel(DataChannelTypes.SEND);
+          await this.createAndSendOffer();
+        } else {
+          this.createDataChannel(DataChannelTypes.RECEIVE);
+        }
+      } catch (error) {
+        console.log(error);
+        throw error;
+      }
+    };
+
+    teardownPeerConnection = () => {
+      this.dataChannel.close();
+      this.peerConnection.close();
+      this.dataChannel = null;
+      this.peerConnection = null;
+    };
+
+    createPeerConnection = () => {
+      console.log('Creating peer connection');
+      const peerConnection = new RTCPeerConnection({
+        iceServers: [
+          {
+            urls: 'stun:stun.l.google.com:19302'
+          }
+        ]
+      });
+      peerConnection.onicecandidate = iceCandidate => {
+        if (iceCandidate.candidate === null) {
+          console.log('Candidate discovery ended');
+        } else {
+          console.log('Candidate discovered', iceCandidate);
+
+          // socket.io-client seem to enumerate iceCandidate object internally.
+          // All non-enumerable properties are getting ignored while emitting event.
+          // Hence we need to manually construct a new object and send.
+
+          this.sendCandidate({
+            candidate: iceCandidate.candidate,
+            sdpMid: iceCandidate.sdpMid,
+            sdpMLineIndex: iceCandidate.sdpMLineIndex,
+            userNameFragment: iceCandidate.userNameFragment
+          });
+        }
+      };
+      this.peerConnection = peerConnection;
+    };
+
+    createDataChannel = datachannelType => {
+      if (datachannelType === DataChannelTypes.SEND) {
+        console.log('Create sendDataChannel');
+        const sendChannel = this.peerConnection.createDataChannel(
+          'sendDataChannel'
+        );
+        console.log('Created sendDataChannel', sendChannel);
+        sendChannel.onopen = this.onSendChannelOpen;
+        sendChannel.onclose = this.onSendChannelClose;
+        this.dataChannel = sendChannel;
+      } else if (datachannelType === DataChannelTypes.RECEIVE) {
+        console.log('Setting listener for ondatachannel');
+        this.peerConnection.ondatachannel = event => {
+          console.log('ReceiveDataChannel event triggered');
+          const receiveChannel = event.channel;
+          receiveChannel.onmessage = this.onReceiveMessage;
+          receiveChannel.onopen = this.onReceiveChannelOpen;
+          receiveChannel.onclose = this.onReceiveChannelClose;
+          this.dataChannel = receiveChannel;
+        };
+      }
+    };
+
+    createAndSendOffer = async () => {
+      try {
+        // Without sending offerToReceiveAudio or offerToReceiveVideo in the offer config,
+        // SDP is not getting set properly
+        const offer = await this.peerConnection.createOffer({
+          offerToReceiveAudio: true,
+          offerToReceiveVideo: true
+        });
+        await this.peerConnection.setLocalDescription(offer);
+        this.sendOffer(offer);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    sendOffer = offer => {
+      console.log('Sending offer', this.context.room, offer);
+      this.context.socket.emit(
+        'offer',
+        this.context.room,
+        this.props.peerId,
+        offer
+      );
+    };
+
+    sendCandidate = candidate => {
+      console.log('Sending candidate', this.context.room, candidate);
+      this.context.socket.emit(
+        'candidate',
+        this.context.room,
+        this.props.peerId,
+        candidate
+      );
+    };
+
+    sendAnswer = answer => {
+      console.log('Sending answer', this.context.room, answer);
+      this.context.socket.emit(
+        'answer',
+        this.context.room,
+        this.props.peerId,
+        answer
+      );
+    };
+
+    // RTCPeerConnection signalling callback handlers
+
+    onOfferReceived = async (targetPeer, desc) => {
+      if (targetPeer === this.context.myId) {
+        console.log('Offer received', desc);
+        try {
+          await this.peerConnection.setRemoteDescription(desc);
+          await this.peerConnection.setLocalDescription(
+            await this.peerConnection.createAnswer()
+          );
+          this.sendAnswer(this.peerConnection.localDescription);
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    };
+
+    onAnswerReceived = async (targetPeer, desc) => {
+      if (targetPeer === this.context.myId) {
+        console.log('Answer received', desc);
+        await this.peerConnection.setRemoteDescription(desc);
+      }
+    };
+
+    onCandidateReceived = async (targetPeer, iceCandidate) => {
+      if (targetPeer === this.context.myId) {
+        try {
+          console.log('Candidate received', iceCandidate);
+          await this.peerConnection.addIceCandidate(
+            new RTCIceCandidate({
+              candidate: iceCandidate.candidate.candidate,
+              sdpMid: iceCandidate.candidate.sdpMid,
+              sdpMLineIndex: iceCandidate.candidate.sdpMLineIndex,
+              usernameFragment: iceCandidate.candidate.userNameFragment
+            })
+          );
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    };
+
+    // Callback handlers for other methods.
+
+    onFileInfoReceived = (targetPeer, fileInfo) => {
+      if (targetPeer === this.context.myId) {
+        console.log('File info received', fileInfo);
+        this.setState({
+          incomingFileInfo: fileInfo
+        });
+        // TODO: Implement conditional file transfer here if needed.
+
+        this.setupPeerConnectionForDataTransfer();
+        this.context.socket.emit('ready', this.context.room, this.props.peerId);
+      }
+    };
+
+    onPeerReadyForDataTransfer = targetPeer => {
+      if (targetPeer === this.context.myId) {
+        console.log('Peer is ready');
+
+        this.setupPeerConnectionForDataTransfer();
+      }
+    };
+
+    // WebRTC DataChannel callback handler methods
+
+    onReceiveMessage = event => {
+      console.log('onReceiveMessage', event.data);
+      this.downloadBlob(event.data, this.state.incomingFileInfo.name);
+      this.teardownPeerConnection();
+    };
+
+    onReceiveChannelOpen = event => {
+      console.log('onReceiveChannelOpen', event);
+    };
+
+    onReceiveChannelClose = event => {
+      console.log('onReceiveChannelClose', event);
+    };
+
+    onSendChannelOpen = event => {
+      console.log('onSendChannelOpen', event);
+      this.dataChannel.send(this.state.files[0]);
+    };
+
+    onSendChannelClose = event => {
+      console.log('onSendChannelClose', event);
+      this.teardownPeerConnection();
+    };
+
+    // Util methods
+
+    downloadBlob = (blob, filename) => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename || 'download';
+      a.click();
+    };
+
+    sendFiles = files => {
+      this.setState({
+        files
+      });
+      this.sendFileInfo(files);
+    };
+
+    sendFileInfo = files => {
+      const fileInfo = {
+        name: files[0].name,
+        size: files[0].size
+      };
+      this.context.socket.emit(
+        'fileInfo',
+        this.context.room,
+        this.props.peerId,
+        fileInfo
+      );
+    };
+
+    render() {
+      return <WrappedComponent {...this.props} sendFiles={this.sendFiles} />;
+    }
+  }
+  PeerConnection.contextType = SocketContext;
+
+  return PeerConnection;
+};
+
+export default withPeerConnection;

--- a/src/contexts/SocketContext.js
+++ b/src/contexts/SocketContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const SocketContext = React.createContext();
+
+export default SocketContext;

--- a/src/enums/PeerConnectionHandshakeStatus.js
+++ b/src/enums/PeerConnectionHandshakeStatus.js
@@ -1,0 +1,5 @@
+export default {
+  NOT_STARTED: 'NOT_STARTED',
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED'
+};


### PR DESCRIPTION
- Use React Context to handle socket connection objects inside child components.
- Move all RTCPeerConnection lifecycle management to Peer component.
- Support for blob transfer - one file.
- PeerConnection is created and destroyed for each file transfer